### PR TITLE
Quick fix for queries that begin with comments

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,10 @@
 # Change log for the Ad-hoc database queries report
 
+## Changes in 20190909.00
+
+* Fix a bug where queries beginning with a comment do not run properly. (First pass.)
+* Correct datetime format for single-row reports.
+
 ## Changes in 20190827.01
 
 * Add time for single-row queries.

--- a/edit_form.php
+++ b/edit_form.php
@@ -195,7 +195,9 @@ class report_customsql_edit_form extends moodleform {
 
             if (!isset($errors['params']) && ! isset($errors['querysql'])) {
                 try {
-                    $rs = report_customsql_execute_query($sql, $paramvalues, 2);
+                    // 2019.09.09.00
+                    $rs = report_customsql_execute_query($sql, $paramvalues, 2,
+                        (empty($data['unsafe']) ? false : $data['unsafe']));
 
                     if (!empty($data['singlerow'])) {
                         // Count rows for Moodle 2 as all Moodle 1.9 useful and more performant

--- a/locallib.php
+++ b/locallib.php
@@ -159,7 +159,7 @@ function report_customsql_generate_csv($report, $timenow) {
         }
         if ($report->singlerow) {
             // 2019.08.27.01, 2019.09.09.00
-            array_unshift($data, strftime('%Y-%m-%d %H:%M', $timenow));
+            array_unshift($data, strftime('%F %T', $timenow));
         }
         report_customsql_write_csv_row($handle, $data);
     }

--- a/locallib.php
+++ b/locallib.php
@@ -31,7 +31,7 @@ define('REPORT_CUSTOMSQL_MAX_RECORDS', 5000);
 define('REPORT_CUSTOMSQL_START_OF_WEEK', 6); // Saturday.
 
 function report_customsql_execute_query($sql, $params = null,
-        $limitnum = REPORT_CUSTOMSQL_MAX_RECORDS) {
+        $limitnum = REPORT_CUSTOMSQL_MAX_RECORDS, $unsafe = false) {
     global $CFG, $DB;
 
     $sql = preg_replace('/\bprefix_(?=\w+)/i', $CFG->prefix, $sql);
@@ -45,8 +45,8 @@ function report_customsql_execute_query($sql, $params = null,
     // 2019.08.26.00
     // Test for multiple queries in unsafe SQL.
     if (strpos($sql, ';') === false) {
-        // 2019.08.20.00
-        if (strtoupper(substr($sql, 0, 5)) == 'SELEC') {
+        // 2019.08.20.00, 2019.09.09.00
+        if (strtoupper(substr($sql, 0, 5)) == 'SELEC' || ! $unsafe) {
             // Note: throws Exception if there is an error.
             return $DB->get_recordset_sql($sql, $params, 0, $limitnum);
         } else {
@@ -132,7 +132,8 @@ function report_customsql_generate_csv($report, $timenow) {
         ? 0
         : $report->csvlimit;
 
-    $rs = report_customsql_execute_query($sql, $queryparams, $querylimit);
+    // 2019.09.09.00
+    $rs = report_customsql_execute_query($sql, $queryparams, $querylimit, $report->unsafe);
 
     $csvfilenames = array();
     $csvtimestamp = null;
@@ -157,7 +158,8 @@ function report_customsql_generate_csv($report, $timenow) {
             }
         }
         if ($report->singlerow) {
-            array_unshift($data, strftime('%Y-%m-%d %H:%i', $timenow));
+            // 2019.08.27.01, 2019.09.09.00
+            array_unshift($data, strftime('%Y-%m-%d %H:%M', $timenow));
         }
         report_customsql_write_csv_row($handle, $data);
     }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2019082701;
+$plugin->version   = 2019090900;
 $plugin->requires  = 2017051500;
 $plugin->component = 'report_customsql';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
TODO: Create a function that does more robust checking to determine query type.

Also corrects a bug with the datetime format for single-row queries.